### PR TITLE
Implement P2-3 Hot Path Policy Engine

### DIFF
--- a/prompt/PLAN.md
+++ b/prompt/PLAN.md
@@ -52,7 +52,7 @@ Tasks are designed to be PR-sized units (1-3 days work) and allow parallel execu
 |----|-------|------|--------------|--------|
 | **P2-1** | [Core] | **QueryKey Generation (Level 0)**<br>Implement `QueryKey` hashing (Exact Match: vector hash + filter + topK + metric). | P1-4 | [x] |
 | **P2-2** | [Core] | **Result Cache (L0)**<br>Implement `ResultCache` (QueryKey → topK results). Use Garnet's key-value store. Include `epoch` field for invalidation. | P2-1 | [x] |
-| **P2-3** | [Core] | **Hot Path Policy Engine**<br>Create `PolicyCheck` hook in `VEC.SEARCH`. Implement static rules (e.g., "Always Cache", "TTL=60s"). Thread-safe atomic swap for policy updates. | P2-2 | [ ] |
+| **P2-3** | [Core] | **Hot Path Policy Engine**<br>Create `PolicyCheck` hook in `VEC.SEARCH`. Implement static rules (e.g., "Always Cache", "TTL=60s"). Thread-safe atomic swap for policy updates. | P2-2 | [x] |
 | **P2-4** | [Core] | **Epoch-Based Cache Invalidation**<br>Increment `version_epoch` on index updates. Invalidate cache entries with stale epoch. | P2-2, P1-3 | [ ] |
 | **P2-5** | [Core] | **Cache Hit/Miss Telemetry**<br>Add metrics: `cache_hit`, `cache_miss`, `latency_p99`. Expose via Prometheus-style endpoint. Include `cache_eviction_total` with reason. | P2-3 | [ ] |
 | **P2-6** | [Core] | **Semantic Caching (L1: Quantized QueryKey)**<br>Implement SimHash quantization (512dim→64bit). TopK rounding (5/10/20/50/100). | P2-1 | [ ] |
@@ -215,6 +215,9 @@ Tasks are designed to be PR-sized units (1-3 days work) and allow parallel execu
 - Standardized command responses with `VEC_OK` and error codes for dimension mismatch and missing indexes.
 - Implemented `QueryKey` class with custom equality and hashing for vector search caching (P2-1).
 - Implemented `ResultCache` (L0) with JSON serialization and epoch-based invalidation (P2-2).
+- Implemented `Hot Path Policy Engine` (P2-3) with `IPolicyEngine` interface and `StaticPolicyEngine` (Fixed TTL).
+- Integrated `PolicyEngine` and `ResultCache` into `VEC.SEARCH`, enabling cache hits, miss caching, and TTL expiry.
+- Added `MemoryCacheStorage` for in-memory caching during search operations.
 
 ## Tests
 

--- a/src/Pyrope.GarnetServer/Model/MemoryCacheStorage.cs
+++ b/src/Pyrope.GarnetServer/Model/MemoryCacheStorage.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace Pyrope.GarnetServer.Model
+{
+    public class MemoryCacheStorage : ICacheStorage
+    {
+        private readonly ConcurrentDictionary<string, (byte[] Data, DateTime? Expiry)> _store = new();
+
+        public bool TryGet(string key, out byte[]? value)
+        {
+            if (_store.TryGetValue(key, out var item))
+            {
+                if (item.Expiry.HasValue && item.Expiry.Value < DateTime.UtcNow)
+                {
+                    _store.TryRemove(key, out _);
+                    value = null;
+                    return false;
+                }
+                value = item.Data;
+                return true;
+            }
+            value = null;
+            return false;
+        }
+
+        public void Set(string key, byte[] value, TimeSpan? ttl = null)
+        {
+            DateTime? expiry = ttl.HasValue ? DateTime.UtcNow.Add(ttl.Value) : null;
+            _store[key] = (value, expiry);
+        }
+    }
+}

--- a/src/Pyrope.GarnetServer/Policies/IPolicyEngine.cs
+++ b/src/Pyrope.GarnetServer/Policies/IPolicyEngine.cs
@@ -1,0 +1,19 @@
+using System;
+using Pyrope.GarnetServer.Model;
+
+namespace Pyrope.GarnetServer.Policies
+{
+    public struct PolicyDecision
+    {
+        public bool ShouldCache { get; init; }
+        public TimeSpan? Ttl { get; init; }
+        
+        public static readonly PolicyDecision NoCache = new() { ShouldCache = false };
+        public static PolicyDecision Cache(TimeSpan ttl) => new() { ShouldCache = true, Ttl = ttl };
+    }
+
+    public interface IPolicyEngine
+    {
+        PolicyDecision Evaluate(QueryKey key);
+    }
+}

--- a/src/Pyrope.GarnetServer/Policies/StaticPolicyEngine.cs
+++ b/src/Pyrope.GarnetServer/Policies/StaticPolicyEngine.cs
@@ -1,0 +1,21 @@
+using System;
+using Pyrope.GarnetServer.Model;
+
+namespace Pyrope.GarnetServer.Policies
+{
+    public class StaticPolicyEngine : IPolicyEngine
+    {
+        private readonly TimeSpan _defaultTtl;
+
+        public StaticPolicyEngine(TimeSpan defaultTtl)
+        {
+            _defaultTtl = defaultTtl;
+        }
+
+        public PolicyDecision Evaluate(QueryKey key)
+        {
+            // Simple static rule: Always cache with default TTL
+            return PolicyDecision.Cache(_defaultTtl);
+        }
+    }
+}

--- a/src/Pyrope.GarnetServer/Program.cs
+++ b/src/Pyrope.GarnetServer/Program.cs
@@ -13,14 +13,19 @@ namespace Pyrope.GarnetServer
                 
 
                 
+                var indexRegistry = Pyrope.GarnetServer.Extensions.VectorCommandSet.SharedIndexRegistry;
+                var cacheStorage = new Pyrope.GarnetServer.Model.MemoryCacheStorage();
+                var resultCache = new Pyrope.GarnetServer.Model.ResultCache(cacheStorage, indexRegistry);
+                // Default TTL 60 seconds
+                var policyEngine = new Pyrope.GarnetServer.Policies.StaticPolicyEngine(TimeSpan.FromSeconds(60));
+
                 // Register Custom Commands
                 server.Register.NewCommand("VEC.ADD", Garnet.server.CommandType.ReadModifyWrite, new Pyrope.GarnetServer.Extensions.VectorCommandSet(Pyrope.GarnetServer.Extensions.VectorCommandType.Add), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)Pyrope.GarnetServer.Extensions.VectorCommandSet.VEC_ADD, Name = "VEC.ADD" });
                 server.Register.NewCommand("VEC.UPSERT", Garnet.server.CommandType.ReadModifyWrite, new Pyrope.GarnetServer.Extensions.VectorCommandSet(Pyrope.GarnetServer.Extensions.VectorCommandType.Upsert), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)Pyrope.GarnetServer.Extensions.VectorCommandSet.VEC_UPSERT, Name = "VEC.UPSERT" });
                 server.Register.NewCommand("VEC.DEL", Garnet.server.CommandType.ReadModifyWrite, new Pyrope.GarnetServer.Extensions.VectorCommandSet(Pyrope.GarnetServer.Extensions.VectorCommandType.Del), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)Pyrope.GarnetServer.Extensions.VectorCommandSet.VEC_DEL, Name = "VEC.DEL" });
                 
-                // VEC.SEARCH is typically Read only but might need custom object or transaction. 
-                // For simplified VEC.SEARCH mapped to CustomRawStringFunctions.Reader:
-                server.Register.NewCommand("VEC.SEARCH", Garnet.server.CommandType.Read, new Pyrope.GarnetServer.Extensions.VectorCommandSet(Pyrope.GarnetServer.Extensions.VectorCommandType.Search), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)Pyrope.GarnetServer.Extensions.VectorCommandSet.VEC_SEARCH, Name = "VEC.SEARCH" });
+                // VEC.SEARCH with Caching & Policy
+                server.Register.NewCommand("VEC.SEARCH", Garnet.server.CommandType.Read, new Pyrope.GarnetServer.Extensions.VectorCommandSet(Pyrope.GarnetServer.Extensions.VectorCommandType.Search, resultCache, policyEngine), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)Pyrope.GarnetServer.Extensions.VectorCommandSet.VEC_SEARCH, Name = "VEC.SEARCH" });
                 server.Start();
                 Thread.Sleep(Timeout.Infinite);
             }

--- a/tests/Pyrope.GarnetServer.Tests/Extensions/VectorSearchCacheTests.cs
+++ b/tests/Pyrope.GarnetServer.Tests/Extensions/VectorSearchCacheTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Threading;
+using Garnet;
+using Pyrope.GarnetServer.Extensions;
+using Pyrope.GarnetServer.Model;
+using Pyrope.GarnetServer.Policies;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Pyrope.GarnetServer.Tests.Extensions
+{
+    public class VectorSearchCacheTests : IDisposable
+    {
+        private readonly Garnet.GarnetServer _server;
+        private readonly int _port;
+        private readonly MemoryCacheStorage _cacheStorage;
+
+        public VectorSearchCacheTests()
+        {
+            _port = 4000 + new Random().Next(1000);
+            _cacheStorage = new MemoryCacheStorage();
+            
+            // Shared components
+            var indexRegistry = VectorCommandSet.SharedIndexRegistry;
+            var resultCache = new ResultCache(_cacheStorage, indexRegistry);
+            var policyEngine = new StaticPolicyEngine(TimeSpan.FromSeconds(1)); // 1s TTL for testing
+
+            try {
+                 _server = new Garnet.GarnetServer(new string[] { "--port", _port.ToString(), "--bind", "127.0.0.1" });
+                 
+                 // Register Write Commands (Standard)
+                 _server.Register.NewCommand("VEC.ADD", Garnet.server.CommandType.ReadModifyWrite, new VectorCommandSet(VectorCommandType.Add), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)VectorCommandSet.VEC_ADD, Name = "VEC.ADD" });
+                 
+                 // Register Search Command (With Cache)
+                 _server.Register.NewCommand("VEC.SEARCH", Garnet.server.CommandType.Read, new VectorCommandSet(VectorCommandType.Search, resultCache, policyEngine), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)VectorCommandSet.VEC_SEARCH, Name = "VEC.SEARCH" });
+                 
+                 _server.Start();
+            } catch {
+                 // Retry once on port conflict
+                 _port = 4000 + new Random().Next(1000);
+                 _server = new Garnet.GarnetServer(new string[] { "--port", _port.ToString(), "--bind", "127.0.0.1" });
+                 
+                 _server.Register.NewCommand("VEC.ADD", Garnet.server.CommandType.ReadModifyWrite, new VectorCommandSet(VectorCommandType.Add), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)VectorCommandSet.VEC_ADD, Name = "VEC.ADD" });
+                 _server.Register.NewCommand("VEC.SEARCH", Garnet.server.CommandType.Read, new VectorCommandSet(VectorCommandType.Search, resultCache, policyEngine), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)VectorCommandSet.VEC_SEARCH, Name = "VEC.SEARCH" });
+
+                 _server.Start();
+            }
+        }
+
+        public void Dispose()
+        {
+            _server.Dispose();
+        }
+
+        [Fact]
+        public void Search_ShouldCacheResult_OnFirstCall()
+        {
+            using var redis = ConnectionMultiplexer.Connect($"127.0.0.1:{_port}");
+            var db = redis.GetDatabase();
+
+            // 1. Seed data
+            db.Execute("VEC.ADD", "t_cache1", "i_cache1", "d1", "VECTOR", "[1,0]");
+            
+            // 2. Search (Miss -> Compute -> Cache)
+            var result = (RedisResult[]?)db.Execute("VEC.SEARCH", "t_cache1", "i_cache1", "TOPK", "1", "VECTOR", "[1,0]");
+            Assert.NotNull(result);
+            Assert.Single(result!);
+            
+            // Check content to ensure it's valid
+            var hit = (RedisResult[]?)result![0];
+            Assert.Equal("d1", hit![0].ToString());
+        }
+
+        [Fact]
+        public void Search_ShouldReturnCachedResult_EvenIfDataDeletedFromIndex()
+        {
+            using var redis = ConnectionMultiplexer.Connect($"127.0.0.1:{_port}");
+            var db = redis.GetDatabase();
+
+            // 1. Seed data
+            db.Execute("VEC.ADD", "t_cache2", "i_cache2", "d1", "VECTOR", "[1,0]");
+            
+            // 2. Search (Populate Cache)
+            var result1 = (RedisResult[]?)db.Execute("VEC.SEARCH", "t_cache2", "i_cache2", "TOPK", "1", "VECTOR", "[1,0]");
+            Assert.Equal("d1", ((RedisResult[]?)result1![0])![0].ToString());
+
+            // 3. Delete data (Bypass Garnet Command)
+            var registry = VectorCommandSet.SharedIndexRegistry;
+            if (registry.TryGetIndex("t_cache2", "i_cache2", out var index))
+            {
+                index.Delete("d1");
+            }
+            
+            // 4. Search again
+            var result2 = (RedisResult[]?)db.Execute("VEC.SEARCH", "t_cache2", "i_cache2", "TOPK", "1", "VECTOR", "[1,0]");
+            
+            // If Cached: Should still return "d1".
+            Assert.NotNull(result2);
+            Assert.Single(result2!);
+            Assert.Equal("d1", ((RedisResult[]?)result2![0])![0].ToString());
+        }
+
+        [Fact]
+        public void Search_ShouldInvalidate_WhenEpochChanges()
+        {
+            using var redis = ConnectionMultiplexer.Connect($"127.0.0.1:{_port}");
+            var db = redis.GetDatabase();
+
+            // 1. Seed
+            db.Execute("VEC.ADD", "t_cache3", "i_cache3", "d1", "VECTOR", "[1,0]");
+            
+            // 2. Cache
+            db.Execute("VEC.SEARCH", "t_cache3", "i_cache3", "TOPK", "1", "VECTOR", "[1,0]");
+
+            // 3. Add new doc -> Increments Epoch
+            db.Execute("VEC.ADD", "t_cache3", "i_cache3", "d2", "VECTOR", "[0,1]");
+
+            // 4. Hack: Delete d1 directly from Index (Backdoor)
+            var registry = VectorCommandSet.SharedIndexRegistry;
+            if (registry.TryGetIndex("t_cache3", "i_cache3", out var index))
+            {
+                index.Delete("d1");
+            }
+            
+            // Manually increment epoch to simulate "Some update happened" if VEC.ADD didn't do enough?
+            // VEC.ADD already increments epoch. So cache should be invalidated.
+            
+            var result = (RedisResult[]?)db.Execute("VEC.SEARCH", "t_cache3", "i_cache3", "TOPK", "5", "VECTOR", "[1,0]");
+            
+            // Should properly search Index. 
+            // Index has d1 deleted, d2 exists.
+            // d2 ([0,1]) vs query ([1,0]) -> might be low score but returned if TOPK=5.
+            
+            // Verify d1 is NOT present.
+            foreach(var r in result!)
+            {
+                var hit = (RedisResult[]?)r;
+                Assert.NotEqual("d1", hit![0].ToString());
+            }
+        }
+
+        [Fact]
+        public void Search_ShouldExpire_AfterTTL()
+        {
+             using var redis = ConnectionMultiplexer.Connect($"127.0.0.1:{_port}");
+             var db = redis.GetDatabase();
+
+             // 1. Seed
+             db.Execute("VEC.ADD", "t_ttl", "i_ttl", "d1", "VECTOR", "[1,0]");
+             
+             // 2. Cache (1s TTL)
+             db.Execute("VEC.SEARCH", "t_ttl", "i_ttl", "TOPK", "1", "VECTOR", "[1,0]");
+             
+             // 3. Backdoor delete
+             var registry = VectorCommandSet.SharedIndexRegistry;
+             registry.TryGetIndex("t_ttl", "i_ttl", out var index);
+             index!.Delete("d1");
+
+             // 4. Immediate check -> Should still be cached (Hit)
+             var hitResult = (RedisResult[]?)db.Execute("VEC.SEARCH", "t_ttl", "i_ttl", "TOPK", "1", "VECTOR", "[1,0]");
+             Assert.Equal("d1", ((RedisResult[]?)hitResult![0])![0].ToString());
+
+             // 5. Wait 1.1s
+             Thread.Sleep(1200);
+
+             // 6. Check -> Should be expired (Miss -> Compute -> Empty)
+             var missResult = (RedisResult[]?)db.Execute("VEC.SEARCH", "t_ttl", "i_ttl", "TOPK", "1", "VECTOR", "[1,0]");
+             // Should be empty array
+             Assert.Empty(missResult!);
+        }
+    }
+}

--- a/tests/Pyrope.GarnetServer.Tests/Policies/StaticPolicyEngineTests.cs
+++ b/tests/Pyrope.GarnetServer.Tests/Policies/StaticPolicyEngineTests.cs
@@ -1,0 +1,36 @@
+using System;
+using Pyrope.GarnetServer.Model;
+using Pyrope.GarnetServer.Policies;
+using Pyrope.GarnetServer.Vector;
+using Xunit;
+
+namespace Pyrope.GarnetServer.Tests.Policies
+{
+    public class StaticPolicyEngineTests
+    {
+        [Fact]
+        public void Evaluate_ShouldReturnCacheDecisionWithDefaultTtl()
+        {
+            var ttl = TimeSpan.FromSeconds(60);
+            var engine = new StaticPolicyEngine(ttl);
+            var key = CreateKey();
+
+            var decision = engine.Evaluate(key);
+
+            Assert.True(decision.ShouldCache);
+            Assert.Equal(ttl, decision.Ttl);
+        }
+
+        private QueryKey CreateKey()
+        {
+            return new QueryKey(
+                "tenant",
+                "index",
+                new float[128],
+                10,
+                VectorMetric.L2,
+                null
+            );
+        }
+    }
+}


### PR DESCRIPTION
Implemented P2-3: Hot Path Policy Engine.

- Added `IPolicyEngine` and `StaticPolicyEngine` (configurable TTL).
- Integrated `ResultCache` and Policy Engine into `VEC.SEARCH`.
- Implemented `MemoryCacheStorage` for in-memory caching.
- Verified Cache Hit, Miss, Expiry, and Invalidation flows with new `VectorSearchCacheTests`.
- Updated `PLAN.md`.