### PR TITLE
feat(telemetry): Implement P2-5 Cache Hit/Miss Telemetry

### DIFF
--- a/src/Pyrope.GarnetServer/Program.cs
+++ b/src/Pyrope.GarnetServer/Program.cs
@@ -15,7 +15,9 @@ namespace Pyrope.GarnetServer
                 
                 var indexRegistry = Pyrope.GarnetServer.Extensions.VectorCommandSet.SharedIndexRegistry;
                 var cacheStorage = new Pyrope.GarnetServer.Model.MemoryCacheStorage();
-                var resultCache = new Pyrope.GarnetServer.Model.ResultCache(cacheStorage, indexRegistry);
+                var metricsCollector = new Pyrope.GarnetServer.Services.MetricsCollector();
+                
+                var resultCache = new Pyrope.GarnetServer.Model.ResultCache(cacheStorage, indexRegistry, metricsCollector);
                 // Default TTL 60 seconds
                 var policyEngine = new Pyrope.GarnetServer.Policies.StaticPolicyEngine(TimeSpan.FromSeconds(60));
 
@@ -24,8 +26,11 @@ namespace Pyrope.GarnetServer
                 server.Register.NewCommand("VEC.UPSERT", Garnet.server.CommandType.ReadModifyWrite, new Pyrope.GarnetServer.Extensions.VectorCommandSet(Pyrope.GarnetServer.Extensions.VectorCommandType.Upsert), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)Pyrope.GarnetServer.Extensions.VectorCommandSet.VEC_UPSERT, Name = "VEC.UPSERT" });
                 server.Register.NewCommand("VEC.DEL", Garnet.server.CommandType.ReadModifyWrite, new Pyrope.GarnetServer.Extensions.VectorCommandSet(Pyrope.GarnetServer.Extensions.VectorCommandType.Del), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)Pyrope.GarnetServer.Extensions.VectorCommandSet.VEC_DEL, Name = "VEC.DEL" });
                 
-                // VEC.SEARCH with Caching & Policy
-                server.Register.NewCommand("VEC.SEARCH", Garnet.server.CommandType.Read, new Pyrope.GarnetServer.Extensions.VectorCommandSet(Pyrope.GarnetServer.Extensions.VectorCommandType.Search, resultCache, policyEngine), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)Pyrope.GarnetServer.Extensions.VectorCommandSet.VEC_SEARCH, Name = "VEC.SEARCH" });
+                // VEC.SEARCH with Caching & Policy & Metrics
+                server.Register.NewCommand("VEC.SEARCH", Garnet.server.CommandType.Read, new Pyrope.GarnetServer.Extensions.VectorCommandSet(Pyrope.GarnetServer.Extensions.VectorCommandType.Search, resultCache, policyEngine, metricsCollector), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)Pyrope.GarnetServer.Extensions.VectorCommandSet.VEC_SEARCH, Name = "VEC.SEARCH" });
+
+                // VEC.STATS
+                server.Register.NewCommand("VEC.STATS", Garnet.server.CommandType.Read, new Pyrope.GarnetServer.Extensions.VectorCommandSet(Pyrope.GarnetServer.Extensions.VectorCommandType.Stats, null, null, metricsCollector), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)Pyrope.GarnetServer.Extensions.VectorCommandSet.VEC_STATS, Name = "VEC.STATS" });
                 server.Start();
                 Thread.Sleep(Timeout.Infinite);
             }

--- a/src/Pyrope.GarnetServer/Services/IMetricsCollector.cs
+++ b/src/Pyrope.GarnetServer/Services/IMetricsCollector.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Pyrope.GarnetServer.Services
+{
+    public interface IMetricsCollector
+    {
+        void RecordCacheHit();
+        void RecordCacheMiss();
+        void RecordSearchLatency(TimeSpan duration);
+        void RecordEviction(string reason);
+        string GetStats();
+        void Reset();
+    }
+}

--- a/src/Pyrope.GarnetServer/Services/MetricsCollector.cs
+++ b/src/Pyrope.GarnetServer/Services/MetricsCollector.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Text;
+using System.Threading;
+
+namespace Pyrope.GarnetServer.Services
+{
+    public class MetricsCollector : IMetricsCollector
+    {
+        private long _cacheHits;
+        private long _cacheMisses;
+        private long _evictions;
+        
+        // Simple latency buckets (count)
+        // <1ms, <5ms, <10ms, <50ms, <100ms, >100ms
+        private readonly long[] _latencyBuckets = new long[6];
+
+        public void RecordCacheHit()
+        {
+            Interlocked.Increment(ref _cacheHits);
+        }
+
+        public void RecordCacheMiss()
+        {
+            Interlocked.Increment(ref _cacheMisses);
+        }
+
+        public void RecordEviction(string reason)
+        {
+            // For MVP just counting total evictions, reason is logged or ignored for agg.
+            Interlocked.Increment(ref _evictions);
+        }
+
+        public void RecordSearchLatency(TimeSpan duration)
+        {
+            var ms = duration.TotalMilliseconds;
+            int bucketIndex;
+
+            if (ms < 1) bucketIndex = 0;
+            else if (ms < 5) bucketIndex = 1;
+            else if (ms < 10) bucketIndex = 2;
+            else if (ms < 50) bucketIndex = 3;
+            else if (ms < 100) bucketIndex = 4;
+            else bucketIndex = 5;
+
+            Interlocked.Increment(ref _latencyBuckets[bucketIndex]);
+        }
+
+        public string GetStats()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"# HELP cache_hit_total Total number of cache hits");
+            sb.AppendLine($"# TYPE cache_hit_total counter");
+            sb.AppendLine($"cache_hit_total {Interlocked.Read(ref _cacheHits)}");
+            
+            sb.AppendLine($"# HELP cache_miss_total Total number of cache misses");
+            sb.AppendLine($"# TYPE cache_miss_total counter");
+            sb.AppendLine($"cache_miss_total {Interlocked.Read(ref _cacheMisses)}");
+
+            sb.AppendLine($"# HELP cache_eviction_total Total number of cache evictions");
+            sb.AppendLine($"# TYPE cache_eviction_total counter");
+            sb.AppendLine($"cache_eviction_total {Interlocked.Read(ref _evictions)}");
+
+            sb.AppendLine($"# HELP vector_search_latency_ms Latency buckets");
+            sb.AppendLine($"# TYPE vector_search_latency_ms histogram");
+
+            long count = 0;
+            
+            count += Interlocked.Read(ref _latencyBuckets[0]);
+            sb.AppendLine($"vector_search_latency_ms_bucket{{le=\"1\"}} {count}");
+            
+            count += Interlocked.Read(ref _latencyBuckets[1]);
+            sb.AppendLine($"vector_search_latency_ms_bucket{{le=\"5\"}} {count}");
+            
+            count += Interlocked.Read(ref _latencyBuckets[2]);
+            sb.AppendLine($"vector_search_latency_ms_bucket{{le=\"10\"}} {count}");
+            
+            count += Interlocked.Read(ref _latencyBuckets[3]);
+            sb.AppendLine($"vector_search_latency_ms_bucket{{le=\"50\"}} {count}");
+            
+            count += Interlocked.Read(ref _latencyBuckets[4]);
+            sb.AppendLine($"vector_search_latency_ms_bucket{{le=\"100\"}} {count}");
+            
+            count += Interlocked.Read(ref _latencyBuckets[5]);
+            sb.AppendLine($"vector_search_latency_ms_bucket{{le=\"+Inf\"}} {count}");
+            
+            sb.AppendLine($"vector_search_latency_ms_count {count}");
+            sb.AppendLine($"vector_search_latency_ms_sum 0"); // Sum not implemented yet
+            
+            return sb.ToString();
+        }
+
+        public void Reset()
+        {
+            Interlocked.Exchange(ref _cacheHits, 0);
+            Interlocked.Exchange(ref _cacheMisses, 0);
+            Interlocked.Exchange(ref _evictions, 0);
+            for (int i = 0; i < _latencyBuckets.Length; i++)
+            {
+                Interlocked.Exchange(ref _latencyBuckets[i], 0);
+            }
+        }
+    }
+}

--- a/tests/Pyrope.GarnetServer.Tests/Extensions/VectorStatsTests.cs
+++ b/tests/Pyrope.GarnetServer.Tests/Extensions/VectorStatsTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Threading;
+using Garnet;
+using Pyrope.GarnetServer.Extensions;
+using Pyrope.GarnetServer.Model;
+using Pyrope.GarnetServer.Policies;
+using Pyrope.GarnetServer.Services;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Pyrope.GarnetServer.Tests.Extensions
+{
+    public class VectorStatsTests : IDisposable
+    {
+        private readonly Garnet.GarnetServer _server;
+        private readonly int _port;
+
+        public VectorStatsTests()
+        {
+            _port = 5000 + new Random().Next(1000);
+            
+            // Shared components
+            var metrics = new MetricsCollector();
+            var indexRegistry = VectorCommandSet.SharedIndexRegistry;
+            var cacheStorage = new MemoryCacheStorage();
+            var resultCache = new ResultCache(cacheStorage, indexRegistry, metrics);
+            var policyEngine = new StaticPolicyEngine(TimeSpan.FromSeconds(60));
+
+
+            try {
+                 _server = new Garnet.GarnetServer(new string[] { "--port", _port.ToString(), "--bind", "127.0.0.1" });
+                 
+                 _server.Register.NewCommand("VEC.ADD", Garnet.server.CommandType.ReadModifyWrite, new VectorCommandSet(VectorCommandType.Add), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)VectorCommandSet.VEC_ADD, Name = "VEC.ADD" });
+                 _server.Register.NewCommand("VEC.SEARCH", Garnet.server.CommandType.Read, new VectorCommandSet(VectorCommandType.Search, resultCache, policyEngine, metrics), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)VectorCommandSet.VEC_SEARCH, Name = "VEC.SEARCH" });
+                 _server.Register.NewCommand("VEC.STATS", Garnet.server.CommandType.Read, new VectorCommandSet(VectorCommandType.Stats, null, null, metrics), new Garnet.server.RespCommandsInfo { Command = (Garnet.server.RespCommand)VectorCommandSet.VEC_STATS, Name = "VEC.STATS" });
+                 
+                 _server.Start();
+            } catch {
+                 // Retry logic omitted for brevity in test, assumption is low conflict risk
+                 throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            _server.Dispose();
+        }
+
+        [Fact]
+        public void VecStats_ShouldReturnMetrics()
+        {
+            using var redis = ConnectionMultiplexer.Connect($"127.0.0.1:{_port}");
+            var db = redis.GetDatabase();
+
+            // 1. Initial State
+            db.Execute("SET", "sys:dummy", "1");
+            var initialStats = (string?)db.Execute("VEC.STATS", "sys:dummy");
+            Assert.Contains("cache_hit_total 0", initialStats);
+            Assert.Contains("cache_miss_total 0", initialStats);
+
+            // 2. Perform Search (Miss)
+            db.Execute("VEC.ADD", "t_stats", "i_stats", "d1", "VECTOR", "[1,0]");
+            db.Execute("VEC.SEARCH", "t_stats", "i_stats", "TOPK", "1", "VECTOR", "[1,0]");
+
+            var missStats = (string?)db.Execute("VEC.STATS", "sys:dummy");
+            Assert.Contains("cache_miss_total 1", missStats);
+            Assert.Contains("cache_hit_total 0", missStats);
+            Assert.Contains("vector_search_latency_ms_bucket{le=\"+Inf\"} 1", missStats);
+
+            // 3. Perform Search (Hit)
+            db.Execute("VEC.SEARCH", "t_stats", "i_stats", "TOPK", "1", "VECTOR", "[1,0]");
+            
+            var hitStats = (string?)db.Execute("VEC.STATS", "sys:dummy");
+            Assert.Contains("cache_miss_total 1", hitStats);
+            Assert.Contains("cache_hit_total 1", hitStats);
+            Assert.Contains("vector_search_latency_ms_bucket{le=\"+Inf\"} 2", hitStats);
+        }
+    }
+}

--- a/tests/Pyrope.GarnetServer.Tests/Services/MetricsCollectorTests.cs
+++ b/tests/Pyrope.GarnetServer.Tests/Services/MetricsCollectorTests.cs
@@ -1,0 +1,55 @@
+using System;
+using Pyrope.GarnetServer.Services;
+using Xunit;
+
+namespace Pyrope.GarnetServer.Tests.Services
+{
+    public class MetricsCollectorTests
+    {
+        [Fact]
+        public void RecordAndGetStats_ShouldReturnCorrectCounts()
+        {
+            var collector = new MetricsCollector();
+            
+            collector.RecordCacheHit();
+            collector.RecordCacheHit();
+            collector.RecordCacheMiss();
+            collector.RecordEviction("ttl");
+
+            var stats = collector.GetStats();
+            
+            Assert.Contains("cache_hit_total 2", stats);
+            Assert.Contains("cache_miss_total 1", stats);
+            Assert.Contains("cache_eviction_total 1", stats);
+        }
+
+        [Fact]
+        public void RecordLatency_ShouldBucketCorrectly()
+        {
+            var collector = new MetricsCollector();
+            
+            collector.RecordSearchLatency(TimeSpan.FromMilliseconds(0.5)); // < 1
+            collector.RecordSearchLatency(TimeSpan.FromMilliseconds(4));   // < 5
+            collector.RecordSearchLatency(TimeSpan.FromMilliseconds(150)); // > 100
+
+            var stats = collector.GetStats();
+
+            Assert.Contains("vector_search_latency_ms_bucket{le=\"1\"} 1", stats);
+            Assert.Contains("vector_search_latency_ms_bucket{le=\"5\"} 2", stats);
+            Assert.Contains("vector_search_latency_ms_bucket{le=\"+Inf\"} 3", stats);
+            Assert.Contains("vector_search_latency_ms_bucket{le=\"50\"} 2", stats);
+        }
+
+        [Fact]
+        public void Reset_ShouldClearStats()
+        {
+            var collector = new MetricsCollector();
+            collector.RecordCacheHit();
+            
+            collector.Reset();
+            
+            var stats = collector.GetStats();
+            Assert.Contains("cache_hit_total 0", stats);
+        }
+    }
+}


### PR DESCRIPTION
Implements cache telemetry as per P2-5. Adds VEC.STATS command and Prometheus-compatible metrics tracking.