### PR TITLE
Implement sidecar metrics reporting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "3278:3278"
     depends_on:
       - sidecar
+    environment:
+      - PYROPE_SIDECAR_ENDPOINT=http://sidecar:50051
     networks:
       - pyrope-net
 

--- a/prompt/PLAN.md
+++ b/prompt/PLAN.md
@@ -77,7 +77,7 @@ Tasks are designed to be PR-sized units (1-3 days work) and allow parallel execu
 
 | ID | Track | Task | Dependencies | Status |
 |----|-------|------|--------------|--------|
-| **P4-1** | [Core] | **Metrics Aggregation for Sidecar**<br>Collect `QPS`, `MissRate`, `Latency`, `CPU/GPU utilization` in Garnet. Periodically push/pull stats to AI Sidecar via GRPC. | P2-5, P0-3 | [ ] |
+| **P4-1** | [Core] | **Metrics Aggregation for Sidecar**<br>Collect `QPS`, `MissRate`, `Latency`, `CPU/GPU utilization` in Garnet. Periodically push/pull stats to AI Sidecar via GRPC. | P2-5, P0-3 | [x] |
 | **P4-2** | [ML] | **Feature Engineering Pipeline**<br>Implement feature extraction: query features (norm, topK, filter type), system features (QPS, queue depth), history features (hit rate, revisit interval). | P4-1 | [ ] |
 | **P4-3** | [ML] | **Simple Heuristic Policy (Warm Path)**<br>Implement logic in Python: "If MissRate > X, increase TTL". Return updated Policy config (admit, ttl, evict_priority) to Garnet. | P0-2, P4-2 | [ ] |
 | **P4-4** | [Core] | **Policy Update Mechanism**<br>Receive Policy config from Sidecar. Thread-safe update of Hot Path parameters (Atomic swap of Lookup Table/Bloom Filter). | P4-1, P4-3 | [ ] |
@@ -228,12 +228,14 @@ Tasks are designed to be PR-sized units (1-3 days work) and allow parallel execu
 - Added Cache Management API for policy updates, flush, and invalidate operations backed by an in-memory admin store.
 - Added Health and Metrics endpoints returning readiness status and Prometheus-format stats.
 - Added TRACE and request_id support to `VEC.SEARCH` with latency breakdown payloads.
+- Added sidecar metrics reporting with QPS/miss rate/latency/CPU utilization aggregation and GRPC push to the AI sidecar.
 
 ## Tests
 
 - `dotnet test tests/Pyrope.GarnetServer.Tests/Pyrope.GarnetServer.Tests.csproj`
 - `dotnet test Pyrope.sln`
 - `./scripts/check_quality.sh`
+- `./scripts/check_quality.sh` (P4-1)
 
 ---
 

--- a/src/Protos/policy_service.proto
+++ b/src/Protos/policy_service.proto
@@ -4,6 +4,7 @@ package pyrope.policy;
 
 service PolicyService {
   rpc GetIndexPolicy (IndexPolicyRequest) returns (IndexPolicyResponse);
+  rpc ReportSystemMetrics (SystemMetricsRequest) returns (SystemMetricsResponse);
 }
 
 message IndexPolicyRequest {
@@ -18,4 +19,20 @@ message IndexPolicyResponse {
   int32 pq_construction = 2;
   int32 pca_dimension = 3;
   string status = 4;
+}
+
+message SystemMetricsRequest {
+  double qps = 1;
+  double miss_rate = 2;
+  double latency_p99_ms = 3;
+  double cpu_utilization = 4;
+  double gpu_utilization = 5;
+  int64 cache_hit_total = 6;
+  int64 cache_miss_total = 7;
+  int64 timestamp_unix_ms = 8;
+}
+
+message SystemMetricsResponse {
+  string status = 1;
+  int32 next_report_interval_ms = 2;
 }

--- a/src/Pyrope.AISidecar/server.py
+++ b/src/Pyrope.AISidecar/server.py
@@ -12,6 +12,17 @@ class PolicyService(policy_service_pb2_grpc.PolicyServiceServicer):
         print(f"Received request for tenant: {request.tenant_id}, index: {request.index_name}")
         return policy_service_pb2.IndexPolicyResponse(pq_m=16, pq_construction=200, pca_dimension=64, status="OK")
 
+    def ReportSystemMetrics(self, request, context):
+        print(
+            "Metrics: "
+            f"qps={request.qps:.2f} "
+            f"miss_rate={request.miss_rate:.2f} "
+            f"latency_p99_ms={request.latency_p99_ms:.2f} "
+            f"cpu={request.cpu_utilization:.2f} "
+            f"gpu={request.gpu_utilization:.2f}"
+        )
+        return policy_service_pb2.SystemMetricsResponse(status="OK", next_report_interval_ms=0)
+
 
 def serve():
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))

--- a/src/Pyrope.GarnetServer/Program.cs
+++ b/src/Pyrope.GarnetServer/Program.cs
@@ -13,6 +13,8 @@ namespace Pyrope.GarnetServer
     {
         public static void Main(string[] args)
         {
+            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+
             var builder = WebApplication.CreateBuilder(args);
             builder.Services.AddControllers();
 
@@ -23,6 +25,7 @@ namespace Pyrope.GarnetServer
             builder.Services.AddSingleton<ICacheAdmin>(sp => sp.GetRequiredService<MemoryCacheStorage>());
             builder.Services.AddSingleton<IMetricsCollector, MetricsCollector>();
             builder.Services.AddSingleton(sp => (MetricsCollector)sp.GetRequiredService<IMetricsCollector>()); // Alias if needed
+            builder.Services.AddSingleton<ISystemUsageProvider, SystemUsageProvider>();
             builder.Services.AddSingleton<LshService>(_ => new LshService());
             builder.Services.AddSingleton<ResultCache>();
             builder.Services.AddSingleton<CachePolicyStore>();
@@ -35,6 +38,7 @@ namespace Pyrope.GarnetServer
 
             // Register GarnetService as Hosted Service
             builder.Services.AddHostedService<GarnetService>();
+            builder.Services.AddHostedService<SidecarMetricsReporter>();
 
             var app = builder.Build();
             app.MapControllers();

--- a/src/Pyrope.GarnetServer/Pyrope.GarnetServer.csproj
+++ b/src/Pyrope.GarnetServer/Pyrope.GarnetServer.csproj
@@ -9,6 +9,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Garnet" Version="1.0.91" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.66.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.28.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.66.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="..\Protos\policy_service.proto" GrpcServices="Client" />
   </ItemGroup>
 
 </Project>

--- a/src/Pyrope.GarnetServer/Services/IMetricsCollector.cs
+++ b/src/Pyrope.GarnetServer/Services/IMetricsCollector.cs
@@ -9,6 +9,7 @@ namespace Pyrope.GarnetServer.Services
         void RecordSearchLatency(TimeSpan duration);
         void RecordEviction(string reason);
         string GetStats();
+        MetricsSnapshot GetSnapshot();
         void Reset();
     }
 }

--- a/src/Pyrope.GarnetServer/Services/MetricsCollector.cs
+++ b/src/Pyrope.GarnetServer/Services/MetricsCollector.cs
@@ -89,6 +89,21 @@ namespace Pyrope.GarnetServer.Services
             return sb.ToString();
         }
 
+        public MetricsSnapshot GetSnapshot()
+        {
+            var buckets = new long[_latencyBuckets.Length];
+            for (int i = 0; i < _latencyBuckets.Length; i++)
+            {
+                buckets[i] = Interlocked.Read(ref _latencyBuckets[i]);
+            }
+
+            return new MetricsSnapshot(
+                Interlocked.Read(ref _cacheHits),
+                Interlocked.Read(ref _cacheMisses),
+                Interlocked.Read(ref _evictions),
+                buckets);
+        }
+
         public void Reset()
         {
             Interlocked.Exchange(ref _cacheHits, 0);

--- a/src/Pyrope.GarnetServer/Services/MetricsSnapshot.cs
+++ b/src/Pyrope.GarnetServer/Services/MetricsSnapshot.cs
@@ -1,0 +1,8 @@
+namespace Pyrope.GarnetServer.Services
+{
+    public readonly record struct MetricsSnapshot(
+        long CacheHits,
+        long CacheMisses,
+        long Evictions,
+        long[] LatencyBuckets);
+}

--- a/src/Pyrope.GarnetServer/Services/SidecarMetricsCalculator.cs
+++ b/src/Pyrope.GarnetServer/Services/SidecarMetricsCalculator.cs
@@ -1,0 +1,100 @@
+using System;
+
+namespace Pyrope.GarnetServer.Services
+{
+    public sealed record SidecarMetricsReport(
+        double Qps,
+        double MissRate,
+        double LatencyP99Ms,
+        double CpuUtilization,
+        double GpuUtilization,
+        long CacheHitTotal,
+        long CacheMissTotal,
+        long TimestampUnixMs);
+
+    public static class SidecarMetricsCalculator
+    {
+        private static readonly double[] LatencyBucketUpperBoundsMs = { 1, 5, 10, 50, 100, 200 };
+
+        public static SidecarMetricsReport Calculate(
+            MetricsSnapshot current,
+            MetricsSnapshot previous,
+            SystemUsageSnapshot currentSystem,
+            SystemUsageSnapshot previousSystem,
+            int processorCount,
+            double gpuUtilization)
+        {
+            var deltaHits = Math.Max(0, current.CacheHits - previous.CacheHits);
+            var deltaMisses = Math.Max(0, current.CacheMisses - previous.CacheMisses);
+            var totalRequests = deltaHits + deltaMisses;
+
+            var elapsedMs = Math.Max(1, (currentSystem.Timestamp - previousSystem.Timestamp).TotalMilliseconds);
+            var elapsedSeconds = elapsedMs / 1000.0;
+            var qps = totalRequests / elapsedSeconds;
+            var missRate = totalRequests == 0 ? 0 : deltaMisses / (double)totalRequests;
+
+            var latencyP99 = EstimateLatencyP99(current, previous);
+            var cpuUtilization = EstimateCpuUtilization(previousSystem, currentSystem, processorCount);
+
+            return new SidecarMetricsReport(
+                qps,
+                missRate,
+                latencyP99,
+                cpuUtilization,
+                gpuUtilization,
+                current.CacheHits,
+                current.CacheMisses,
+                currentSystem.Timestamp.ToUnixTimeMilliseconds());
+        }
+
+        private static double EstimateLatencyP99(MetricsSnapshot current, MetricsSnapshot previous)
+        {
+            var bucketCount = Math.Min(current.LatencyBuckets.Length, previous.LatencyBuckets.Length);
+            long total = 0;
+            var deltas = new long[bucketCount];
+
+            for (int i = 0; i < bucketCount; i++)
+            {
+                var delta = current.LatencyBuckets[i] - previous.LatencyBuckets[i];
+                deltas[i] = Math.Max(0, delta);
+                total += deltas[i];
+            }
+
+            if (total == 0)
+            {
+                return 0;
+            }
+
+            long cumulative = 0;
+            for (int i = 0; i < bucketCount; i++)
+            {
+                cumulative += deltas[i];
+                if (cumulative / (double)total >= 0.99)
+                {
+                    return LatencyBucketUpperBoundsMs[Math.Min(i, LatencyBucketUpperBoundsMs.Length - 1)];
+                }
+            }
+
+            return LatencyBucketUpperBoundsMs[^1];
+        }
+
+        private static double EstimateCpuUtilization(SystemUsageSnapshot previous, SystemUsageSnapshot current, int processorCount)
+        {
+            if (processorCount <= 0)
+            {
+                return 0;
+            }
+
+            var wallMs = (current.Timestamp - previous.Timestamp).TotalMilliseconds;
+            var cpuMs = (current.CpuTime - previous.CpuTime).TotalMilliseconds;
+
+            if (wallMs <= 0)
+            {
+                return 0;
+            }
+
+            var utilization = cpuMs / (wallMs * processorCount) * 100.0;
+            return Math.Clamp(utilization, 0, 100);
+        }
+    }
+}

--- a/src/Pyrope.GarnetServer/Services/SidecarMetricsReporter.cs
+++ b/src/Pyrope.GarnetServer/Services/SidecarMetricsReporter.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Net.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Pyrope.Policy;
+
+namespace Pyrope.GarnetServer.Services
+{
+    public sealed class SidecarMetricsReporter : BackgroundService
+    {
+        private readonly IMetricsCollector _metricsCollector;
+        private readonly ISystemUsageProvider _systemUsageProvider;
+        private readonly ILogger<SidecarMetricsReporter> _logger;
+        private readonly string? _sidecarEndpoint;
+        private TimeSpan _reportInterval;
+
+        public SidecarMetricsReporter(
+            IMetricsCollector metricsCollector,
+            ISystemUsageProvider systemUsageProvider,
+            IConfiguration configuration,
+            ILogger<SidecarMetricsReporter> logger)
+        {
+            _metricsCollector = metricsCollector;
+            _systemUsageProvider = systemUsageProvider;
+            _logger = logger;
+            _sidecarEndpoint = configuration["Sidecar:Endpoint"] ?? Environment.GetEnvironmentVariable("PYROPE_SIDECAR_ENDPOINT");
+
+            if (!int.TryParse(configuration["Sidecar:MetricsIntervalSeconds"], out var seconds))
+            {
+                seconds = 10;
+            }
+
+            _reportInterval = TimeSpan.FromSeconds(Math.Max(1, seconds));
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            if (string.IsNullOrWhiteSpace(_sidecarEndpoint))
+            {
+                _logger.LogInformation("Sidecar metrics reporting disabled (no endpoint configured).");
+                return;
+            }
+
+            using var channel = GrpcChannel.ForAddress(_sidecarEndpoint);
+            var client = new PolicyService.PolicyServiceClient(channel);
+
+            var previousMetrics = _metricsCollector.GetSnapshot();
+            var previousSystem = _systemUsageProvider.GetSnapshot();
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(_reportInterval, stoppingToken);
+                }
+                catch (TaskCanceledException)
+                {
+                    break;
+                }
+
+                var currentMetrics = _metricsCollector.GetSnapshot();
+                var currentSystem = _systemUsageProvider.GetSnapshot();
+
+                var report = SidecarMetricsCalculator.Calculate(
+                    currentMetrics,
+                    previousMetrics,
+                    currentSystem,
+                    previousSystem,
+                    _systemUsageProvider.ProcessorCount,
+                    gpuUtilization: -1);
+
+                previousMetrics = currentMetrics;
+                previousSystem = currentSystem;
+
+                var request = new SystemMetricsRequest
+                {
+                    Qps = report.Qps,
+                    MissRate = report.MissRate,
+                    LatencyP99Ms = report.LatencyP99Ms,
+                    CpuUtilization = report.CpuUtilization,
+                    GpuUtilization = report.GpuUtilization,
+                    CacheHitTotal = report.CacheHitTotal,
+                    CacheMissTotal = report.CacheMissTotal,
+                    TimestampUnixMs = report.TimestampUnixMs
+                };
+
+                try
+                {
+                    var response = await client.ReportSystemMetricsAsync(request, cancellationToken: stoppingToken);
+                    if (response.NextReportIntervalMs > 0)
+                    {
+                        _reportInterval = TimeSpan.FromMilliseconds(response.NextReportIntervalMs);
+                    }
+                }
+                catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
+                {
+                    _logger.LogWarning(ex, "Failed to report metrics to sidecar");
+                }
+            }
+        }
+    }
+}

--- a/src/Pyrope.GarnetServer/Services/SystemUsageProvider.cs
+++ b/src/Pyrope.GarnetServer/Services/SystemUsageProvider.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Diagnostics;
+
+namespace Pyrope.GarnetServer.Services
+{
+    public readonly record struct SystemUsageSnapshot(DateTimeOffset Timestamp, TimeSpan CpuTime);
+
+    public interface ISystemUsageProvider
+    {
+        int ProcessorCount { get; }
+        SystemUsageSnapshot GetSnapshot();
+    }
+
+    public sealed class SystemUsageProvider : ISystemUsageProvider
+    {
+        public int ProcessorCount { get; } = Environment.ProcessorCount;
+
+        public SystemUsageSnapshot GetSnapshot()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var cpu = Process.GetCurrentProcess().TotalProcessorTime;
+            return new SystemUsageSnapshot(now, cpu);
+        }
+    }
+}

--- a/tests/Pyrope.GarnetServer.Tests/Services/MetricsCollectorTests.cs
+++ b/tests/Pyrope.GarnetServer.Tests/Services/MetricsCollectorTests.cs
@@ -51,5 +51,22 @@ namespace Pyrope.GarnetServer.Tests.Services
             var stats = collector.GetStats();
             Assert.Contains("cache_hit_total 0", stats);
         }
+
+        [Fact]
+        public void GetSnapshot_ShouldReturnTotals()
+        {
+            var collector = new MetricsCollector();
+            collector.RecordCacheHit();
+            collector.RecordCacheMiss();
+            collector.RecordEviction("ttl");
+            collector.RecordSearchLatency(TimeSpan.FromMilliseconds(2));
+
+            var snapshot = collector.GetSnapshot();
+
+            Assert.Equal(1, snapshot.CacheHits);
+            Assert.Equal(1, snapshot.CacheMisses);
+            Assert.Equal(1, snapshot.Evictions);
+            Assert.Equal(1, snapshot.LatencyBuckets[1]);
+        }
     }
 }

--- a/tests/Pyrope.GarnetServer.Tests/Services/SidecarMetricsCalculatorTests.cs
+++ b/tests/Pyrope.GarnetServer.Tests/Services/SidecarMetricsCalculatorTests.cs
@@ -1,0 +1,36 @@
+using System;
+using Pyrope.GarnetServer.Services;
+using Xunit;
+
+namespace Pyrope.GarnetServer.Tests.Services
+{
+    public class SidecarMetricsCalculatorTests
+    {
+        [Fact]
+        public void Calculate_ShouldComputeQpsAndMissRate()
+        {
+            var previous = new MetricsSnapshot(10, 5, 0, new long[] { 5, 0, 0, 0, 0, 0 });
+            var current = new MetricsSnapshot(20, 15, 0, new long[] { 5, 5, 0, 0, 0, 0 });
+
+            var prevSystem = new SystemUsageSnapshot(
+                DateTimeOffset.FromUnixTimeMilliseconds(0),
+                TimeSpan.FromSeconds(1));
+            var currSystem = new SystemUsageSnapshot(
+                DateTimeOffset.FromUnixTimeMilliseconds(10_000),
+                TimeSpan.FromSeconds(5));
+
+            var report = SidecarMetricsCalculator.Calculate(
+                current,
+                previous,
+                currSystem,
+                prevSystem,
+                processorCount: 2,
+                gpuUtilization: -1);
+
+            Assert.Equal(2.0, report.Qps, 3);
+            Assert.Equal(0.5, report.MissRate, 3);
+            Assert.Equal(5, report.LatencyP99Ms);
+            Assert.True(report.CpuUtilization > 0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add gRPC metrics reporting from Garnet to AI sidecar (QPS/miss rate/latency/CPU)
- add metrics snapshot + calculation utilities and tests
- update sidecar proto/handler and docker-compose endpoint

## Testing
- ./scripts/check_quality.sh