### PR TITLE
P5-1: Enforce tenant namespace validation

### DIFF
--- a/prompt/SPEC.md
+++ b/prompt/SPEC.md
@@ -205,6 +205,7 @@ sequenceDiagram
 制約
 
 * id最大長、meta最大バイト、タグ数上限
+* tenant_id / index_name は `[A-Za-z0-9_-]+`（英数字と _ - のみ）
 * dimはindex単位で固定
 
 ### 4.2 インデックス定義（IndexConfig）

--- a/src/Pyrope.GarnetServer/Controllers/CacheController.cs
+++ b/src/Pyrope.GarnetServer/Controllers/CacheController.cs
@@ -56,6 +56,16 @@ namespace Pyrope.GarnetServer.Controllers
                 return BadRequest("TenantId and IndexName are required.");
             }
 
+            if (!TenantNamespace.TryValidateTenantId(request.TenantId, out var tenantError))
+            {
+                return BadRequest(tenantError);
+            }
+
+            if (!TenantNamespace.TryValidateIndexName(request.IndexName, out var indexError))
+            {
+                return BadRequest(indexError);
+            }
+
             var prefix = KeyUtils.GetCacheKeyPrefix(request.TenantId, request.IndexName);
             var removed = _cacheAdmin.RemoveByPrefix(prefix);
             return Ok(new { Removed = removed });

--- a/src/Pyrope.GarnetServer/Controllers/IndexController.cs
+++ b/src/Pyrope.GarnetServer/Controllers/IndexController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Pyrope.GarnetServer.Extensions;
 using Pyrope.GarnetServer.Services;
+using Pyrope.GarnetServer.Utils;
 using Pyrope.GarnetServer.Vector;
 
 namespace Pyrope.GarnetServer.Controllers
@@ -22,6 +23,16 @@ namespace Pyrope.GarnetServer.Controllers
             if (request == null || string.IsNullOrWhiteSpace(request.TenantId) || string.IsNullOrWhiteSpace(request.IndexName))
                 return BadRequest("Invalid request.");
 
+            if (!TenantNamespace.TryValidateTenantId(request.TenantId, out var tenantError))
+            {
+                return BadRequest(tenantError);
+            }
+
+            if (!TenantNamespace.TryValidateIndexName(request.IndexName, out var indexError))
+            {
+                return BadRequest(indexError);
+            }
+
             try
             {
                 var metric = Enum.Parse<VectorMetric>(request.Metric, true);
@@ -37,6 +48,16 @@ namespace Pyrope.GarnetServer.Controllers
         [HttpPost("{tenantId}/{indexName}/build")]
         public IActionResult BuildIndex(string tenantId, string indexName)
         {
+            if (!TenantNamespace.TryValidateTenantId(tenantId, out var tenantError))
+            {
+                return BadRequest(tenantError);
+            }
+
+            if (!TenantNamespace.TryValidateIndexName(indexName, out var indexError))
+            {
+                return BadRequest(indexError);
+            }
+
             if (_registry.TryGetIndex(tenantId, indexName, out var index))
             {
                 index.Build();
@@ -51,6 +72,16 @@ namespace Pyrope.GarnetServer.Controllers
             if (request == null || string.IsNullOrWhiteSpace(request.Path))
             {
                 return BadRequest("Path is required.");
+            }
+
+            if (!TenantNamespace.TryValidateTenantId(tenantId, out var tenantError))
+            {
+                return BadRequest(tenantError);
+            }
+
+            if (!TenantNamespace.TryValidateIndexName(indexName, out var indexError))
+            {
+                return BadRequest(indexError);
             }
 
             if (_registry.TryGetIndex(tenantId, indexName, out var index))
@@ -76,6 +107,16 @@ namespace Pyrope.GarnetServer.Controllers
                 return BadRequest("Path is required.");
             }
 
+            if (!TenantNamespace.TryValidateTenantId(tenantId, out var tenantError))
+            {
+                return BadRequest(tenantError);
+            }
+
+            if (!TenantNamespace.TryValidateIndexName(indexName, out var indexError))
+            {
+                return BadRequest(indexError);
+            }
+
             if (_registry.TryGetIndex(tenantId, indexName, out var index))
             {
                 try
@@ -94,6 +135,16 @@ namespace Pyrope.GarnetServer.Controllers
         [HttpGet("{tenantId}/{indexName}/stats")]
         public IActionResult GetStats(string tenantId, string indexName)
         {
+            if (!TenantNamespace.TryValidateTenantId(tenantId, out var tenantError))
+            {
+                return BadRequest(tenantError);
+            }
+
+            if (!TenantNamespace.TryValidateIndexName(indexName, out var indexError))
+            {
+                return BadRequest(indexError);
+            }
+
             if (_registry.TryGetIndex(tenantId, indexName, out var index))
             {
                 return Ok(index.GetStats());

--- a/src/Pyrope.GarnetServer/Controllers/TenantController.cs
+++ b/src/Pyrope.GarnetServer/Controllers/TenantController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Pyrope.GarnetServer.Model;
 using Pyrope.GarnetServer.Services;
+using Pyrope.GarnetServer.Utils;
 
 namespace Pyrope.GarnetServer.Controllers
 {
@@ -23,6 +24,11 @@ namespace Pyrope.GarnetServer.Controllers
                 return BadRequest("Invalid request.");
             }
 
+            if (!TenantNamespace.TryValidateTenantId(request.TenantId, out var error))
+            {
+                return BadRequest(error);
+            }
+
             var quotas = request.Quotas ?? new TenantQuota();
             if (_registry.TryCreate(request.TenantId, quotas, out var config))
             {
@@ -35,6 +41,11 @@ namespace Pyrope.GarnetServer.Controllers
         [HttpGet("{tenantId}/quotas")]
         public IActionResult GetQuotas(string tenantId)
         {
+            if (!TenantNamespace.TryValidateTenantId(tenantId, out var error))
+            {
+                return BadRequest(error);
+            }
+
             if (_registry.TryGet(tenantId, out var config))
             {
                 return Ok(config!.Quotas);
@@ -49,6 +60,11 @@ namespace Pyrope.GarnetServer.Controllers
             if (request == null)
             {
                 return BadRequest("Invalid request.");
+            }
+
+            if (!TenantNamespace.TryValidateTenantId(tenantId, out var error))
+            {
+                return BadRequest(error);
             }
 
             if (_registry.TryUpdateQuotas(tenantId, request, out var config))

--- a/src/Pyrope.GarnetServer/Extensions/VectorCommandParser.cs
+++ b/src/Pyrope.GarnetServer/Extensions/VectorCommandParser.cs
@@ -79,7 +79,9 @@ namespace Pyrope.GarnetServer.Extensions
             }
 
             var tenantId = args[0];
+            TenantNamespace.ValidateTenantId(tenantId);
             var indexName = args[1];
+            TenantNamespace.ValidateIndexName(indexName);
             var id = args[2];
             var vectorToken = args[3];
             if (!vectorToken.Equals("VECTOR", StringComparison.OrdinalIgnoreCase))
@@ -141,13 +143,14 @@ namespace Pyrope.GarnetServer.Extensions
         public static VectorCommandRequest Parse(string tenantId, IReadOnlyList<ArgSlice> args)
         {
             if (args == null) throw new ArgumentNullException(nameof(args));
-            if (string.IsNullOrWhiteSpace(tenantId)) throw new ArgumentException("Tenant id cannot be empty.", nameof(tenantId));
+            TenantNamespace.ValidateTenantId(tenantId);
             if (args.Count < 4)
             {
                 throw new ArgumentException("Expected at least 4 arguments: index id VECTOR <payload>.");
             }
 
             var indexName = Decode(args[0]);
+            TenantNamespace.ValidateIndexName(indexName);
             var id = Decode(args[1]);
             var vectorToken = Decode(args[2]);
             if (!vectorToken.Equals("VECTOR", StringComparison.OrdinalIgnoreCase))
@@ -209,13 +212,14 @@ namespace Pyrope.GarnetServer.Extensions
         public static VectorSearchRequest ParseSearch(string tenantId, IReadOnlyList<ArgSlice> args)
         {
             if (args == null) throw new ArgumentNullException(nameof(args));
-            if (string.IsNullOrWhiteSpace(tenantId)) throw new ArgumentException("Tenant id cannot be empty.", nameof(tenantId));
+            TenantNamespace.ValidateTenantId(tenantId);
             if (args.Count < 5)
             {
                 throw new ArgumentException("Expected at least 5 arguments: index TOPK <k> VECTOR <payload>.");
             }
 
             var indexName = Decode(args[0]);
+            TenantNamespace.ValidateIndexName(indexName);
             var token = Decode(args[1]);
             if (!token.Equals("TOPK", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Pyrope.GarnetServer/Model/QueryKey.cs
+++ b/src/Pyrope.GarnetServer/Model/QueryKey.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Pyrope.GarnetServer.Utils;
 using Pyrope.GarnetServer.Vector;
 
 namespace Pyrope.GarnetServer.Model
@@ -25,6 +26,8 @@ namespace Pyrope.GarnetServer.Model
             IReadOnlyList<string>? filterTags,
             long? simHash = null)
         {
+            TenantNamespace.ValidateTenantId(tenantId);
+            TenantNamespace.ValidateIndexName(indexName);
             TenantId = tenantId;
             IndexName = indexName;
             Vector = vector;

--- a/src/Pyrope.GarnetServer/Services/IndexMetadataManager.cs
+++ b/src/Pyrope.GarnetServer/Services/IndexMetadataManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text.Json;
 using Pyrope.GarnetServer.Model;
+using Pyrope.GarnetServer.Utils;
 
 namespace Pyrope.GarnetServer.Services
 {
@@ -10,8 +11,8 @@ namespace Pyrope.GarnetServer.Services
 
         public string GetMetadataKey(string tenantId, string indexName)
         {
-            if (string.IsNullOrWhiteSpace(tenantId)) throw new ArgumentException("Tenant ID cannot be empty", nameof(tenantId));
-            if (string.IsNullOrWhiteSpace(indexName)) throw new ArgumentException("Index Name cannot be empty", nameof(indexName));
+            TenantNamespace.ValidateTenantId(tenantId);
+            TenantNamespace.ValidateIndexName(indexName);
 
             return $"{Prefix}:{tenantId}:{indexName}";
         }

--- a/src/Pyrope.GarnetServer/Services/TenantRegistry.cs
+++ b/src/Pyrope.GarnetServer/Services/TenantRegistry.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using Pyrope.GarnetServer.Model;
+using Pyrope.GarnetServer.Utils;
 
 namespace Pyrope.GarnetServer.Services
 {
@@ -10,6 +11,7 @@ namespace Pyrope.GarnetServer.Services
 
         public bool TryCreate(string tenantId, TenantQuota quotas, out TenantConfig? config)
         {
+            TenantNamespace.ValidateTenantId(tenantId);
             var now = DateTimeOffset.UtcNow;
             var tenantConfig = new TenantConfig(tenantId, quotas, now);
             if (_tenants.TryAdd(tenantId, tenantConfig))
@@ -24,11 +26,13 @@ namespace Pyrope.GarnetServer.Services
 
         public bool TryGet(string tenantId, out TenantConfig? config)
         {
+            TenantNamespace.ValidateTenantId(tenantId);
             return _tenants.TryGetValue(tenantId, out config);
         }
 
         public bool TryUpdateQuotas(string tenantId, TenantQuota quotas, out TenantConfig? config)
         {
+            TenantNamespace.ValidateTenantId(tenantId);
             if (_tenants.TryGetValue(tenantId, out var existing))
             {
                 existing.UpdateQuotas(quotas, DateTimeOffset.UtcNow);

--- a/src/Pyrope.GarnetServer/Services/VectorIndexRegistry.cs
+++ b/src/Pyrope.GarnetServer/Services/VectorIndexRegistry.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using Pyrope.GarnetServer.Vector;
+using Pyrope.GarnetServer.Utils;
 
 namespace Pyrope.GarnetServer.Services
 {
@@ -11,8 +12,8 @@ namespace Pyrope.GarnetServer.Services
 
         public IVectorIndex GetOrCreate(string tenantId, string indexName, int dimension, VectorMetric metric)
         {
-            if (string.IsNullOrWhiteSpace(tenantId)) throw new ArgumentException("Tenant id cannot be empty.", nameof(tenantId));
-            if (string.IsNullOrWhiteSpace(indexName)) throw new ArgumentException("Index name cannot be empty.", nameof(indexName));
+            TenantNamespace.ValidateTenantId(tenantId);
+            TenantNamespace.ValidateIndexName(indexName);
 
             var key = GetIndexKey(tenantId, indexName);
             var state = _indices.GetOrAdd(key, _ => new IndexState(dimension, metric));
@@ -32,8 +33,8 @@ namespace Pyrope.GarnetServer.Services
 
         public bool TryGetIndex(string tenantId, string indexName, out IVectorIndex index)
         {
-            if (string.IsNullOrWhiteSpace(tenantId)) throw new ArgumentException("Tenant id cannot be empty.", nameof(tenantId));
-            if (string.IsNullOrWhiteSpace(indexName)) throw new ArgumentException("Index name cannot be empty.", nameof(indexName));
+            TenantNamespace.ValidateTenantId(tenantId);
+            TenantNamespace.ValidateIndexName(indexName);
 
             var key = GetIndexKey(tenantId, indexName);
             if (_indices.TryGetValue(key, out var state))
@@ -48,8 +49,8 @@ namespace Pyrope.GarnetServer.Services
 
         public long IncrementEpoch(string tenantId, string indexName)
         {
-            if (string.IsNullOrWhiteSpace(tenantId)) throw new ArgumentException("Tenant id cannot be empty.", nameof(tenantId));
-            if (string.IsNullOrWhiteSpace(indexName)) throw new ArgumentException("Index name cannot be empty.", nameof(indexName));
+            TenantNamespace.ValidateTenantId(tenantId);
+            TenantNamespace.ValidateIndexName(indexName);
 
             var key = GetIndexKey(tenantId, indexName);
             return _indices.TryGetValue(key, out var state) ? state.IncrementEpoch() : 0;
@@ -57,8 +58,8 @@ namespace Pyrope.GarnetServer.Services
 
         public long GetEpoch(string tenantId, string indexName)
         {
-            if (string.IsNullOrWhiteSpace(tenantId)) throw new ArgumentException("Tenant id cannot be empty.", nameof(tenantId));
-            if (string.IsNullOrWhiteSpace(indexName)) throw new ArgumentException("Index name cannot be empty.", nameof(indexName));
+            TenantNamespace.ValidateTenantId(tenantId);
+            TenantNamespace.ValidateIndexName(indexName);
 
             var key = GetIndexKey(tenantId, indexName);
             return _indices.TryGetValue(key, out var state) ? state.Epoch : 0;

--- a/src/Pyrope.GarnetServer/Services/VectorStore.cs
+++ b/src/Pyrope.GarnetServer/Services/VectorStore.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Pyrope.GarnetServer.Model;
+using Pyrope.GarnetServer.Utils;
 
 namespace Pyrope.GarnetServer.Services
 {
@@ -63,8 +64,8 @@ namespace Pyrope.GarnetServer.Services
 
         private static string GetRecordKey(string tenantId, string indexName, string id)
         {
-            if (string.IsNullOrWhiteSpace(tenantId)) throw new ArgumentException("Tenant id cannot be empty.", nameof(tenantId));
-            if (string.IsNullOrWhiteSpace(indexName)) throw new ArgumentException("Index name cannot be empty.", nameof(indexName));
+            TenantNamespace.ValidateTenantId(tenantId);
+            TenantNamespace.ValidateIndexName(indexName);
             if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Id cannot be empty.", nameof(id));
 
             return $"{tenantId}:{indexName}:{id}";

--- a/src/Pyrope.GarnetServer/Utils/KeyUtils.cs
+++ b/src/Pyrope.GarnetServer/Utils/KeyUtils.cs
@@ -4,16 +4,21 @@ namespace Pyrope.GarnetServer.Utils
     {
         public static string GetIndexConfigKey(string tenantId, string indexName)
         {
+            TenantNamespace.ValidateTenantId(tenantId);
+            TenantNamespace.ValidateIndexName(indexName);
             return $"_meta:tenant:{tenantId}:index:{indexName}:config";
         }
 
         public static string GetTenantConfigKey(string tenantId)
         {
+            TenantNamespace.ValidateTenantId(tenantId);
             return $"_meta:tenant:{tenantId}:config";
         }
 
         public static string GetCacheKeyPrefix(string tenantId, string indexName)
         {
+            TenantNamespace.ValidateTenantId(tenantId);
+            TenantNamespace.ValidateIndexName(indexName);
             return $"cache:{tenantId}:{indexName}:";
         }
     }

--- a/src/Pyrope.GarnetServer/Utils/TenantNamespace.cs
+++ b/src/Pyrope.GarnetServer/Utils/TenantNamespace.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Pyrope.GarnetServer.Utils
+{
+    public static class TenantNamespace
+    {
+        private static readonly Regex SegmentPattern = new("^[A-Za-z0-9_-]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        public static bool TryValidateTenantId(string tenantId, out string? errorMessage)
+        {
+            return TryValidateSegment("TenantId", tenantId, out errorMessage);
+        }
+
+        public static bool TryValidateIndexName(string indexName, out string? errorMessage)
+        {
+            return TryValidateSegment("IndexName", indexName, out errorMessage);
+        }
+
+        public static void ValidateTenantId(string tenantId)
+        {
+            if (!TryValidateTenantId(tenantId, out var errorMessage))
+            {
+                throw new ArgumentException(errorMessage, nameof(tenantId));
+            }
+        }
+
+        public static void ValidateIndexName(string indexName)
+        {
+            if (!TryValidateIndexName(indexName, out var errorMessage))
+            {
+                throw new ArgumentException(errorMessage, nameof(indexName));
+            }
+        }
+
+        private static bool TryValidateSegment(string label, string value, out string? errorMessage)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                errorMessage = $"{label} is required.";
+                return false;
+            }
+
+            if (!SegmentPattern.IsMatch(value))
+            {
+                errorMessage = $"{label} must match [A-Za-z0-9_-]+ (letters, digits, underscore, hyphen).";
+                return false;
+            }
+
+            errorMessage = null;
+            return true;
+        }
+    }
+}

--- a/tests/Pyrope.GarnetServer.Tests/Utils/KeyUtilsTests.cs
+++ b/tests/Pyrope.GarnetServer.Tests/Utils/KeyUtilsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Xunit;
 using Pyrope.GarnetServer.Utils;
 
@@ -17,6 +18,22 @@ namespace Pyrope.GarnetServer.Tests.Utils
         {
             var key = KeyUtils.GetTenantConfigKey("tenant1");
             Assert.Equal("_meta:tenant:tenant1:config", key);
+        }
+
+        [Theory]
+        [InlineData("tenant:bad", "indexA")]
+        [InlineData("tenant1", "index:bad")]
+        public void GetIndexConfigKey_RejectsInvalidSegments(string tenantId, string indexName)
+        {
+            Assert.Throws<ArgumentException>(() => KeyUtils.GetIndexConfigKey(tenantId, indexName));
+        }
+
+        [Theory]
+        [InlineData("tenant:bad")]
+        [InlineData("tenant bad")]
+        public void GetTenantConfigKey_RejectsInvalidTenant(string tenantId)
+        {
+            Assert.Throws<ArgumentException>(() => KeyUtils.GetTenantConfigKey(tenantId));
         }
     }
 }

--- a/tests/Pyrope.GarnetServer.Tests/Utils/TenantNamespaceTests.cs
+++ b/tests/Pyrope.GarnetServer.Tests/Utils/TenantNamespaceTests.cs
@@ -1,0 +1,51 @@
+using Pyrope.GarnetServer.Utils;
+using Xunit;
+
+namespace Pyrope.GarnetServer.Tests.Utils
+{
+    public class TenantNamespaceTests
+    {
+        [Theory]
+        [InlineData("tenant1")]
+        [InlineData("tenant_1")]
+        [InlineData("tenant-1")]
+        [InlineData("TENANT")]
+        public void TryValidateTenantId_AllowsSafeSegments(string tenantId)
+        {
+            Assert.True(TenantNamespace.TryValidateTenantId(tenantId, out var error));
+            Assert.Null(error);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("tenant:bad")]
+        [InlineData("tenant/bad")]
+        [InlineData("tenant bad")]
+        public void TryValidateTenantId_RejectsUnsafeSegments(string tenantId)
+        {
+            Assert.False(TenantNamespace.TryValidateTenantId(tenantId, out var error));
+            Assert.NotNull(error);
+        }
+
+        [Theory]
+        [InlineData("index1")]
+        [InlineData("index_1")]
+        [InlineData("index-1")]
+        public void TryValidateIndexName_AllowsSafeSegments(string indexName)
+        {
+            Assert.True(TenantNamespace.TryValidateIndexName(indexName, out var error));
+            Assert.Null(error);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("index:bad")]
+        [InlineData("index bad")]
+        public void TryValidateIndexName_RejectsUnsafeSegments(string indexName)
+        {
+            Assert.False(TenantNamespace.TryValidateIndexName(indexName, out var error));
+            Assert.NotNull(error);
+        }
+    }
+}

--- a/tests/Pyrope.GarnetServer.Tests/Vector/VectorCommandParserTests.cs
+++ b/tests/Pyrope.GarnetServer.Tests/Vector/VectorCommandParserTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Pyrope.GarnetServer.Extensions;
 using Xunit;
@@ -33,6 +34,36 @@ namespace Pyrope.GarnetServer.Tests.Vector
             Assert.Equal("{\"source\":\"news\"}", request.MetaJson);
             Assert.Equal(new[] { "hot", "fresh" }, request.Tags);
             Assert.Equal(1.5, request.NumericFields["score"]);
+        }
+
+        [Fact]
+        public void Parse_RejectsInvalidTenantId()
+        {
+            var args = new List<string>
+            {
+                "tenant:bad",
+                "indexA",
+                "doc1",
+                "VECTOR",
+                "[1.0]"
+            };
+
+            Assert.Throws<ArgumentException>(() => VectorCommandParser.Parse(args));
+        }
+
+        [Fact]
+        public void Parse_RejectsInvalidIndexName()
+        {
+            var args = new List<string>
+            {
+                "tenantA",
+                "index:bad",
+                "doc1",
+                "VECTOR",
+                "[1.0]"
+            };
+
+            Assert.Throws<ArgumentException>(() => VectorCommandParser.Parse(args));
         }
     }
 }


### PR DESCRIPTION
## Summary
- enforce tenant/index namespace validation across commands, services, and APIs
- add shared TenantNamespace utility with clearer validation errors
- document allowed tenant/index characters and add tests

## Testing
- dotnet test Pyrope.sln
- ./scripts/check_quality.sh